### PR TITLE
fix: corriger l'ordre des règles .htaccess racine OVH

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,14 +1,15 @@
 <IfModule mod_rewrite.c>
+    Options +FollowSymLinks
     RewriteEngine On
-
-    # Bloquer l'accès direct aux dossiers et fichiers sensibles
-    RewriteRule ^(app|bootstrap|config|database|resources|routes|storage|tests|vendor)(/|$) - [F,L]
-    RewriteRule ^(\.env|composer\.(json|lock)|package(-lock)?\.json|webpack\.mix\.js|artisan)$ - [F,L]
 
     # Si le fichier ou dossier existe dans public/, le servir directement
     RewriteCond %{DOCUMENT_ROOT}/public/%{REQUEST_URI} -f [OR]
     RewriteCond %{DOCUMENT_ROOT}/public/%{REQUEST_URI} -d
     RewriteRule ^(.*)$ public/$1 [L]
+
+    # Bloquer l'accès direct aux dossiers et fichiers sensibles
+    RewriteRule ^(app|bootstrap|config|database|resources|routes|tests|vendor)(/|$) - [F,L]
+    RewriteRule ^(\.env|composer\.(json|lock)|package(-lock)?\.json|webpack\.mix\.js|artisan)$ - [F,L]
 
     # Tout le reste → front controller Laravel
     RewriteRule ^(.*)$ public/index.php [L]


### PR DESCRIPTION
La règle de blocage storage/ précédait la redirection vers public/, bloquant toutes les requêtes /storage/vignettes/*.