### PR TITLE
fix: retirer Options +FollowSymLinks (interdit sur OVH mutualisé)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,4 @@
 <IfModule mod_rewrite.c>
-    Options +FollowSymLinks
     RewriteEngine On
 
     # Si le fichier ou dossier existe dans public/, le servir directement


### PR DESCRIPTION
Causait un 403 global sur tout rechargement de page.