### PR TITLE
fix: corriger le routage des fichiers storage sur OVH mutualisé

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,9 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
+    # Servir les fichiers storage directement via le symlink public/storage
+    RewriteRule ^storage/(.*)$ public/storage/$1 [L]
+
     # Si le fichier ou dossier existe dans public/, le servir directement
     RewriteCond %{DOCUMENT_ROOT}/public/%{REQUEST_URI} -f [OR]
     RewriteCond %{DOCUMENT_ROOT}/public/%{REQUEST_URI} -d

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -36,6 +36,9 @@
     RewriteCond %{REQUEST_URI} (.+)/$
     RewriteRule ^ %1 [L,R=301]
 
+    # Ne pas réécrire les requêtes vers storage/ (fichiers statiques via symlink)
+    RewriteRule ^storage/ - [L]
+
     # Send Requests To Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
La condition -f ne suit pas le symlink public/storage. Ajout d'une règle dédiée storage/ dans les deux .htaccess pour servir les fichiers directement.