### PR TITLE
fix: simplifier .htaccess racine, supprimer les règles de blocage

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,17 +1,10 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
-    # Servir les fichiers storage directement via le symlink public/storage
-    RewriteRule ^storage/(.*)$ public/storage/$1 [L]
-
     # Si le fichier ou dossier existe dans public/, le servir directement
     RewriteCond %{DOCUMENT_ROOT}/public/%{REQUEST_URI} -f [OR]
     RewriteCond %{DOCUMENT_ROOT}/public/%{REQUEST_URI} -d
     RewriteRule ^(.*)$ public/$1 [L]
-
-    # Bloquer l'accès direct aux dossiers et fichiers sensibles
-    RewriteRule ^(app|bootstrap|config|database|resources|routes|tests|vendor)(/|$) - [F,L]
-    RewriteRule ^(\.env|composer\.(json|lock)|package(-lock)?\.json|webpack\.mix\.js|artisan)$ - [F,L]
 
     # Tout le reste → front controller Laravel
     RewriteRule ^(.*)$ public/index.php [L]

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -36,9 +36,6 @@
     RewriteCond %{REQUEST_URI} (.+)/$
     RewriteRule ^ %1 [L,R=301]
 
-    # Ne pas réécrire les requêtes vers storage/ (fichiers statiques via symlink)
-    RewriteRule ^storage/ - [L]
-
     # Send Requests To Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
Les règles de blocage app/bootstrap/... causaient des 403 sur les routes SPA Vue. Inutiles car les fichiers sensibles ne sont pas dans public/.